### PR TITLE
Remove log messages being appended to document

### DIFF
--- a/meta/shell.html
+++ b/meta/shell.html
@@ -38,24 +38,12 @@
             text = Array.prototype.slice.call(arguments).join(" ");
           }
           console.log(text);
-
-          var pre = document.createElement("pre");
-          pre.textContent = text;
-          pre.style.color = "black";
-          document.body.appendChild(pre);
-          window.scrollTo(0, document.body.scrollHeight);
         },
         printErr: function(text) {
           if (arguments.length > 1) {
             text = Array.prototype.slice.call(arguments).join(" ");
           }
           console.error(text);
-
-          var pre = document.createElement("pre");
-          pre.textContent = text;
-          pre.style.color = "red";
-          document.body.appendChild(pre);
-          window.scrollTo(0, document.body.scrollHeight);
         },
         setStatus: function(text) {
           console.log(text);


### PR DESCRIPTION
Appending log messages to the document body and then scrolling to them is making me go crazy. The messages are printed to the console and seem sufficient. Was there a reason this was done? It makes it hard to debug UI when the debug output modifies and scrolls the window.